### PR TITLE
Enhance load test observability with debug mode and parameter updates

### DIFF
--- a/lkr.md
+++ b/lkr.md
@@ -101,7 +101,7 @@ $ lkr load-test:render [OPTIONS]
 * `--attribute TEXT`: Looker attributes to run the test on. Specify them as attribute:value like --attribute store:value. Excepts multiple arguments --attribute store:acme --attribute team:managers. Accepts random.randint(0,1000) format
 * `--result-format TEXT`: Format of the rendered output (pdf, png, jpg)  [default: pdf]
 * `--render-bail-out INTEGER`: How many iterations to wait for the render task to complete (roughly number of seconds)  [default: 120]
-* `--run-once`: Make each user run its render task only once.  [default: false]
+* `--run-once / --no-run-once`: Make each user run its render task only once.  [default: no-run-once]
 * `--help`: Show this message and exit.
 
 ## `lkr load-test:embed-observability`
@@ -140,5 +140,6 @@ $ lkr load-test:embed-observability [OPTIONS]
 * `--completion-timeout INTEGER RANGE`: Timeout in seconds for the dashboard run complete event  [default: 120; x&gt;=1]
 * `--attribute TEXT`: Looker attributes to run the test on. Specify them as attribute:value like --attribute store:value. Excepts multiple arguments --attribute store:acme --attribute team:managers. Accepts random.randint(0,1000) format
 * `--log-event-prefix TEXT`: Prefix to add to the log event  [default: looker-embed-observability]
-* `--do-not-open-url / --no-do-not-open-url`: Do not open the URL in the observability browser, useful for viewing a user&#x27;s embed dashboard when running locally  [default: no-do-not-open-url]
+* `--open-url / --no-open-url`: Do not open the URL in the observability browser, useful for viewing a user&#x27;s embed dashboard when running locally  [default: open-url]
+* `--debug`: Enable debug mode
 * `--help`: Show this message and exit.

--- a/lkr/load_test/embed_dashboard_observability/embed_container.html
+++ b/lkr/load_test/embed_dashboard_observability/embed_container.html
@@ -29,14 +29,19 @@
     <iframe id="looker-iframe" src=""></iframe>
     <script>
         // Get the iframe URL from query parameters
-        const urlParams = new URLSearchParams(window.location.search);
-        const iframeUrl = urlParams.get('iframe_url');
-        const origin = new URL(iframeUrl).origin;
-        const dashboard = urlParams.get('dashboard_id');
-        const user_id = urlParams.get('user_id');
-        const task_id = urlParams.get('task_id');
-        const task_start_time = urlParams.get('task_start_time');
-        const debug = urlParams.get('debug');
+        const url = new URL(window.location.href);
+        const iframeUrl = url.searchParams.get('iframe_url');
+        const looker_url =  new URL(iframeUrl);
+        const origin = looker_url.origin;
+        const dashboard = url.searchParams.get('dashboard_id');
+        const user_id = url.searchParams.get('user_id');
+        const task_id = url.searchParams.get('task_id');
+        const task_start_time = url.searchParams.get('task_start_time');
+        const debug = url.searchParams.get('debug') === 'true';
+        if (debug) {
+            localStorage.setItem("debug", "looker:chatty:*")
+            console.log("href", window.location.href);
+        }
         
         // Set the iframe source
         document.getElementById('looker-iframe').src = iframeUrl;
@@ -47,6 +52,9 @@
 
         // Listen for Looker embed events
         window.addEventListener('message', function(event) {
+            if (debug) {
+                console.log("event message", event.origin, event.data);
+            }
             if (event.origin !== origin) {
                 return;
             }

--- a/lkr/load_test/embed_dashboard_observability/embed_server.py
+++ b/lkr/load_test/embed_dashboard_observability/embed_server.py
@@ -84,4 +84,4 @@ def run_server(port=3000, log_event_prefix="looker_embed_observability"):
 
 
 if __name__ == "__main__":
-    run_server(3000, log_event_prefix="looker_embed_observability")
+    run_server(4000, log_event_prefix="looker_embed_observability")


### PR DESCRIPTION
- Updated command-line options for `lkr load-test:render` and `lkr load-test:embed-observability` to include `--run-once / --no-run-once` and `--open-url / --no-open-url`.
- Introduced a `--debug` option to enable debug mode in the embed observability tests.
- Refactored embed server to use `gevent` for improved concurrency.
- Updated embed container HTML to handle debug logging and URL parameter parsing more effectively.
- Changed default server port from 3000 to 4000 for embed observability.